### PR TITLE
Changes made for the test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.log
 *.synctex.gz
 svg-inkscape/
+num-front/
+num-back/

--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,18 @@ number-pdfs: $(patsubst %, %.pdf, $(ALL_CARD_NAMES) $(CARD_BACKS))
 		if [[ "$$card" != *back.pdf ]]; then \
 			export NUM=$$(( $$NUM + 1 )); \
 			cp -v $$card num-front/$${NUM}.pdf; \
+			inkscape --export-type=png num-front/$${NUM}.pdf \
+				 --export-filename=num-front/$${NUM}.png \
+				 --export-width=816 \
+				 --export-height=1110 \
+				 --export-dpi=300; \
 			export PREFIX=`echo $$card | cut -f1 -d'-'`; \
 			cp -v $$PREFIX-back.pdf num-back/$${NUM}.pdf; \
+			inkscape --export-type=png num-back/$${NUM}.pdf \
+				 --export-filename=num-back/$${NUM}.png \
+				 --export-width=816 \
+				 --export-height=1110 \
+				 --export-dpi=300; \
 		fi \
 	done
 

--- a/templates/starting-template.tex
+++ b/templates/starting-template.tex
@@ -24,22 +24,22 @@
 \rotatebox[origin=c]{90}{
 \pagenumbering{gobble} % turn off pagenumbers
 \hyphenchar\font=-1 % turn off end-of-line word hyphenation
-\ovalbox{
+\fbox{
 \noindent\begin{minipage}[c][5.5cm][c]{7.9cm} % A minipage is used to get a fixed size for the table 5x7.9
 \centering\textbf{Starting state}\\
 % Use a 3x3 table to place the values, but only if there are values given on the card
 \begin{tabular}{p{0.25\linewidth} p{0.25\linewidth} p{0.25\linewidth}}
-\ifthenelse{\isundefined{\upperleft}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\upperleft}}} &
-\ifthenelse{\isundefined{\uppercenter}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\uppercenter}}} &
-\ifthenelse{\isundefined{\upperright}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\upperright}}}\\
+\ifthenelse{\isundefined{\upperleft}}{}{\fbox{\parbox{0.25\textwidth}{\centering\upperleft}}} &
+\ifthenelse{\isundefined{\uppercenter}}{}{\fbox{\parbox{0.25\textwidth}{\centering\uppercenter}}} &
+\ifthenelse{\isundefined{\upperright}}{}{\fbox{\parbox{0.25\textwidth}{\centering\upperright}}}\\
 \\ % blank row to create some space
-\ifthenelse{\isundefined{\middleleft}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\middleleft}}} &
-\ifthenelse{\isundefined{\middlecenter}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\middlecenter}}} &
-\ifthenelse{\isundefined{\middleright}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\middleright}}}\\
+\ifthenelse{\isundefined{\middleleft}}{}{\fbox{\parbox{0.25\textwidth}{\centering\middleleft}}} &
+\ifthenelse{\isundefined{\middlecenter}}{}{\fbox{\parbox{0.25\textwidth}{\centering\middlecenter}}} &
+\ifthenelse{\isundefined{\middleright}}{}{\fbox{\parbox{0.25\textwidth}{\centering\middleright}}}\\
 \\ % blank row to create some space
-\ifthenelse{\isundefined{\lowerleft}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\lowerleft}}} &
-\ifthenelse{\isundefined{\lowercenter}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\lowercenter}}} &
-\ifthenelse{\isundefined{\lowerright}}{}{\ovalbox{\parbox{0.25\textwidth}{\centering\lowerright}}}\\
+\ifthenelse{\isundefined{\lowerleft}}{}{\fbox{\parbox{0.25\textwidth}{\centering\lowerleft}}} &
+\ifthenelse{\isundefined{\lowercenter}}{}{\fbox{\parbox{0.25\textwidth}{\centering\lowercenter}}} &
+\ifthenelse{\isundefined{\lowerright}}{}{\fbox{\parbox{0.25\textwidth}{\centering\lowerright}}}\\
 \end{tabular}
 \end{minipage}
 }


### PR DESCRIPTION
* switch from ovalbox to square fbox
  prevents weirdness with inkscape pdf -> png

* specify png as an output format, with width, height, and DPI
  the printer charges more for PDF than PNG, so we generate PNGs
  the printer requires 816x110, which is not exactly 300DPI
  probably this should be 815x1110, which would be 300DPI
  this may change with future printers

Co-authored-by: Jan Ainali <jan@publiccode.net>