### PR TITLE
Add link to workshop and online instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ For the actual rules, see the rules cards.
 
 ![A picture of the cards in the game on a table](images/cards-640px.jpg)
 
+If you want to use the game in a workshop or online, see [our workshop guide](https://about.publiccode.net/activities/supporting-codebase-governance/game/run-governance-game-workshop.html).
+
 ## Print your own version
 
 See [PRINTING](PRINTING.md) for tested printing methods.


### PR DESCRIPTION
Similar as on the website (see #122), and also useful in the README.