### PR TITLE
Use the makefile target

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -36,6 +36,6 @@ jobs:
           aspell
           aspell-en
       - name: install-fonts
-        run: script/ensure-font.sh
+        run: make ensure-font
       - name: make-check
         run: make check

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -37,7 +37,7 @@ jobs:
           aspell
           aspell-en
       - name: install-fonts
-        run: script/ensure-font.sh
+        run: make ensure-font
       - name: make-release
         run: make release
       - name: create-release-body


### PR DESCRIPTION
As the README instructions use the Makefile target "make ensure-font" the workflow should also.

See: 1278118b2ccf2823b057214ac0a292c077b1e54a